### PR TITLE
[DATAVIC-56] Allow admin level users to create organisations.

### DIFF
--- a/ckanext/workflow/fantastic/workflow.js
+++ b/ckanext/workflow/fantastic/workflow.js
@@ -1,0 +1,4 @@
+  jQuery(document).ready(function() {
+    jQuery('#field-parent option[value=""]').remove();
+    jQuery("#field-parent").val($("#field-parent option:first").val());
+  });

--- a/ckanext/workflow/plugin.py
+++ b/ckanext/workflow/plugin.py
@@ -8,12 +8,38 @@ import ckan.logic as logic
 from ckan.common import config
 from ckanext.workflow import helpers
 from ckanext.workflow.logic import actions
+from ckan.lib.plugins import DefaultOrganizationForm
+
+#from ckanext.hierarchy import helpers as heirarchy_helpers
 
 log1 = logging.getLogger(__name__)
 
+def organization_create(context, data_dict=None):
+    user = toolkit.c.userobj
+    # Sysadmin can do anything
+    if authz.is_sysadmin(user.name):
+        return {'success': True}
+
+    if not authz.auth_is_anon_user(context):
+        orgs = helpers.get_user_organizations(user.name)
+        for org in orgs:
+            role = helpers.role_in_org(org.id, user.name)
+            if role == 'admin':
+                return {'success': True}
+
+    return {'success': False, 'msg': 'Only user level admin or above can create an organisation.'}
+
+
 class WorkflowPlugin(plugins.SingletonPlugin):
     plugins.implements(plugins.IPackageController)
+    plugins.implements(plugins.IAuthFunctions)
     plugins.implements(plugins.IActions)
+
+    # IAuthFunctions
+    def get_auth_functions(self):
+        return {
+            'organization_create': organization_create,
+        }
 
     # IActions
     def get_actions(self):
@@ -127,3 +153,56 @@ class WorkflowPlugin(plugins.SingletonPlugin):
         if helpers.is_private_site_and_user_not_logged_in():
             toolkit.redirect_to('user_login')
         return pkg_dict
+
+
+class DataVicHierarchyForm(plugins.SingletonPlugin, DefaultOrganizationForm):
+
+    plugins.implements(plugins.ITemplateHelpers)
+    plugins.implements(plugins.IConfigurer)
+    plugins.implements(plugins.IGroupForm, inherit=True)
+
+    def is_sysadmin(self):
+        user = toolkit.c.userobj
+        if authz.is_sysadmin(user.name):
+            return True
+        else:
+            print('\n\n\n***** Youre NO sysadmin! get outta here!')
+        return False
+
+    def is_top_level_organization(self, id):
+        group = model.Group.get(id)
+        if group:
+            parent = group.get_parent_group_hierarchy('organization')
+            # This reads a bit funny - but we're checking if the organization has a parent or not
+            if not parent:
+                return True
+        return False
+
+    ## IConfigurer interface ##
+
+    def update_config(self, config):
+        ''' Setup the (fanstatic) resource library, public and template directory '''
+        plugins.toolkit.add_template_directory(config, 'templates')
+        plugins.toolkit.add_resource('fantastic', 'ckanext-workflow')
+
+    ## ITemplateHelpers interface ##
+
+    def get_helpers(self):
+        return {
+            'is_sysadmin': self.is_sysadmin,
+            'is_top_level_organization': self.is_top_level_organization,
+        }
+
+    def group_types(self):
+        return ('organization',)
+
+    def group_controller(self):
+        return 'organization'
+
+    def setup_template_variables(self, context, data_dict):
+        from pylons import tmpl_context as c
+
+        #  DataVic - we filter these in context of logged in user
+        user = toolkit.c.userobj
+
+        c.allowable_parent_groups = user.get_groups('organization', 'admin')

--- a/ckanext/workflow/templates/organization/base_form_page.html
+++ b/ckanext/workflow/templates/organization/base_form_page.html
@@ -1,0 +1,13 @@
+{% ckan_extends %}
+
+{% block primary_content_inner %}
+  {{ super() }}
+
+  {% if c.controller == 'organization' %}
+    {% if (c.action == 'new'
+        or (c.action == 'edit' and h.is_top_level_organization(organization.id) == False))
+        and h.is_sysadmin() == False %}
+      {% resource 'ckanext-workflow/workflow.js' %}
+    {% endif %}
+  {% endif %}
+{% endblock %}

--- a/setup.py
+++ b/setup.py
@@ -81,6 +81,7 @@ setup(
     entry_points='''
         [ckan.plugins]
         workflow=ckanext.workflow.plugin:WorkflowPlugin
+        datavic_heirarchy_form=ckanext.workflow.plugin:DataVicHierarchyForm
 
         [babel.extractors]
         ckan = ckan.lib.extract:extract_ckan


### PR DESCRIPTION
This branch introduces changes to allow non-sysadmin users, who have 'admin' role in at least one organisation to create new organisations.

Those organisations can only be created within organisations the user is an admin of, therefore the "None - top level" option needs to be removed for non-sysadmin users.

That option is hardcoded in the `ckanext-hierarchy`. To avoid forking that extension, jQuery was used to simply remove the option using conditional javascript.

- Add new plugin entry point in setup.py for `datavic_heirarchy_form` plugin (NOTE: this requires `python setup.py develop` to be run)
- Add `datavic_heirarchy_form` plugin to replace the `heirarchy_form` plugin from ckanext-heirarchy
- Add template overrides for `datavic_heirarchy_form` plugin

Once merged, the commit ID in the `datavic_ckan` repo needs to be updated, and update .ini file templates commited.