### PR TITLE
Release: 2.10.7 - DATAVIC-958

### DIFF
--- a/ckanext/workflow/helpers.py
+++ b/ckanext/workflow/helpers.py
@@ -188,11 +188,10 @@ def apply_admin_workflow_status_rules(current_workflow_status, workflow_status):
 
 
 def get_workflow_status_for_role(current_workflow_status, workflow_status, user_name, owner_org_id):
-    user = g.userobj
-    role = role_in_org(owner_org_id, user.name)
+    role = role_in_org(owner_org_id, user_name)
 
     # Sysadmin can do whatever they like..
-    if not authz.is_sysadmin(user.name):
+    if not authz.is_sysadmin(user_name):
         # Validate the workflow_status in context of the user's role
         if role == 'editor':
             workflow_status = apply_editor_workflow_status_rules(current_workflow_status, workflow_status)
@@ -374,8 +373,8 @@ def user_can_view_private_dataset(package, user_name):
 
 
 def is_sysadmin():
-    user = g.userobj
-    if authz.is_sysadmin(user.name):
+    user_name = toolkit.current_user.name if toolkit.current_user else None
+    if authz.is_sysadmin(user_name):
         return True
 
     return False
@@ -410,9 +409,11 @@ def get_activity_diffs(id):
 
     TODO: Check if we need to include `include_hidden_activity`
     '''
+    user = toolkit.current_user if toolkit.current_user else None
+    user_name = user.name if user else None
     context = {
         u'model': model, u'session': model.Session,
-        u'user': g.user, u'auth_user_obj': g.userobj
+        u'user': user_name, u'auth_user_obj': user
     }
     pkg_activity_list = get_action(u'package_activity_list')(context, {
         u'id': id,
@@ -431,9 +432,9 @@ def get_activity_diffs(id):
 
 
 def show_top_level_option(group_id, selected_parent):
-    user = g.user
+    user_name = toolkit.current_user.name if toolkit.current_user else None
     # No restrictions for `sysadmin` users
-    if authz.is_sysadmin(user):
+    if authz.is_sysadmin(user_name):
         return True
     else:
         # Only apply this behaviour if role cascading disabled..

--- a/ckanext/workflow/helpers.py
+++ b/ckanext/workflow/helpers.py
@@ -404,7 +404,7 @@ def is_workflow_enabled(id):
 
 def get_activity_diffs(id):
     '''
-    Get last package_activity_list item
+    Get last package_activity_list item for package activity only.
 
     Returns the activity_diff for that activity_item_id
 
@@ -415,7 +415,10 @@ def get_activity_diffs(id):
         u'user': g.user, u'auth_user_obj': g.userobj
     }
     pkg_activity_list = get_action(u'package_activity_list')(context, {
-        u'id': id, 'limit': 1})
+        u'id': id,
+        'limit': 1,
+        'activity_types': ['new package', 'changed package'],
+    })
 
     if pkg_activity_list:
         activity_diff = get_action('activity_show')(context, {

--- a/ckanext/workflow/hierarchy_form_plugin.py
+++ b/ckanext/workflow/hierarchy_form_plugin.py
@@ -1,3 +1,4 @@
+from re import T
 import ckan.authz as authz
 import ckan.model as model
 import ckan.plugins as plugins
@@ -43,9 +44,9 @@ class DataVicHierarchyForm(plugins.SingletonPlugin, DefaultOrganizationForm):
         #from pylons import tmpl_context as c
 
         #  DataVic - we filter these in context of logged in user
-        user = toolkit.g.userobj
+        user_name = toolkit.current_user.name if toolkit.current_user else None
 
-        if authz.is_sysadmin(user.name):
+        if authz.is_sysadmin(user_name):
             toolkit.g.allowable_parent_groups = model.Group.all(
                 group_type='organization')
         else:
@@ -55,6 +56,6 @@ class DataVicHierarchyForm(plugins.SingletonPlugin, DefaultOrganizationForm):
                 toolkit.g.allowable_parent_groups = \
                     group.groups_allowed_to_be_its_parent(type='organization')
             else:
-                context = {'user': toolkit.g.user}
+                context = {'user': user_name}
                 data_dict = {'permission': None}
                 toolkit.g.allowable_parent_groups = toolkit.get_action('organization_list_for_user')(context, data_dict)

--- a/ckanext/workflow/logic/auth.py
+++ b/ckanext/workflow/logic/auth.py
@@ -37,13 +37,14 @@ def package_show(
 
 def organization_create(context, data_dict=None):
     """Custom code: if user is an admin in any org, allow him to create orgs"""
-    if authz.is_sysadmin(tk.current_user.name):
+    user_name = tk.current_user.name if tk.current_user else None
+    if authz.is_sysadmin(user_name):
         return {"success": True}
 
     if not authz.auth_is_anon_user(context):
-        orgs = helpers.get_user_organizations(tk.current_user.name)
+        orgs = helpers.get_user_organizations(user_name)
         for org in orgs:
-            role = helpers.role_in_org(org.id, tk.current_user.name)
+            role = helpers.role_in_org(org.id, user_name)
             if role == "admin":
                 return {"success": True}
 
@@ -54,7 +55,8 @@ def organization_create(context, data_dict=None):
 
 
 def organization_update(context, data_dict=None):
-    if authz.is_sysadmin(tk.current_user.name):
+    user_name = tk.current_user.name if tk.current_user else None
+    if authz.is_sysadmin(user_name):
         return {"success": True}
 
     if authz.auth_is_anon_user(context):
@@ -72,7 +74,7 @@ def organization_update(context, data_dict=None):
         return {"success": False, "msg": "Missing organization ID."}
 
     if organization_id:
-        role = helpers.role_in_org(organization_id, tk.current_user.name)
+        role = helpers.role_in_org(organization_id, user_name)
         if role == "admin":
             return {"success": True}
 

--- a/ckanext/workflow/workflow_plugin.py
+++ b/ckanext/workflow/workflow_plugin.py
@@ -68,16 +68,13 @@ class WorkflowPlugin(plugins.SingletonPlugin):
                 entity.private = True
 
             # BEGIN: DATAVIC-251 CKAN 2.9 upgrade
-            # BEGIN: DATAVIC-251 CKAN 2.9 upgrade
-            from pprint import pprint
-
             activity_diffs = helpers.get_activity_diffs(entity.id)
             # Check if there are recorded activities
             if activity_diffs:
-                # pprint(activity_diffs.get('activities')[0])
-                previous_workflow_status = (
-                    activity_diffs.get("data").get("package").get("workflow_status")
-                )
+                pkg_data = (
+                    activity_diffs.get("data") or {}
+                ).get("package") or {}
+                previous_workflow_status = pkg_data.get("workflow_status")
 
                 if workflow_status != previous_workflow_status:
                     # If workflow_status changes from draft to ready_for_approval..

--- a/ckanext/workflow/workflow_plugin.py
+++ b/ckanext/workflow/workflow_plugin.py
@@ -49,8 +49,8 @@ class WorkflowPlugin(plugins.SingletonPlugin):
         if repr(toolkit.request) != "<LocalProxy unbound>" and toolkit.get_endpoint()[
             0
         ] in ["package", "dataset", "datavic_dataset"]:
-            user = toolkit.g.userobj
-            role = helpers.role_in_org(entity.owner_org, user.name)
+            user_name = toolkit.current_user.name if toolkit.current_user else None
+            role = helpers.role_in_org(entity.owner_org, user_name)
 
             workflow_status = entity.extras.get("workflow_status", None)
             organization_visibility = entity.extras.get("organization_visibility", None)
@@ -61,7 +61,7 @@ class WorkflowPlugin(plugins.SingletonPlugin):
             if workflow_status == "published" and organization_visibility == "all":
                 # Super Admins can publish datasets
                 # The only other user that can publish datasets are admins of the organization
-                if not authz.is_sysadmin(user.name) and not role == "admin":
+                if not authz.is_sysadmin(user_name) and not role == "admin":
                     entity.private = True
             else:
                 # Dataset is Private until workflow_status becomes "published"
@@ -83,7 +83,7 @@ class WorkflowPlugin(plugins.SingletonPlugin):
                         and workflow_status == "ready_for_approval"
                     ):
                         helpers.notify_admin_users(
-                            entity.owner_org, user.name, entity.name
+                            entity.owner_org, user_name, entity.name
                         )
                     # Else, if workflow_status changes from ready_for_approval back to draft..
                     elif (


### PR DESCRIPTION
## Summary

### DATAVIC Tickets

**[DATAVIC-958](https://digital-vic.atlassian.net/browse/DATAVIC-958) — user_name authorisation refactor and workflow_status resolution**
- `helpers.get_workflow_status_for_role`: now takes `user_name` directly and passes it to `role_in_org` and `authz.is_sysadmin` instead of resolving via `g.userobj`
- `helpers.is_sysadmin`: resolves the current user via `toolkit.current_user` instead of `g.userobj`
- `helpers.show_top_level_option`: uses `toolkit.current_user.name` instead of `g.user`
- `helpers.get_activity_diffs`: filters `package_activity_list` to `activity_types=['new package', 'changed package']` so resource-view activity is ignored when resolving the previous `workflow_status`; builds the action context from `toolkit.current_user`
- `workflow_plugin.WorkflowPlugin.before_dataset_update`: replaces `toolkit.g.userobj` with `toolkit.current_user`; safe-handles a missing `data.package` payload when reading the previous `workflow_status`; removes the unused `pprint` import and dead `DATAVIC-251` comment
- `hierarchy_form_plugin.py` and `logic/auth.py`: same `g.user`/`g.userobj` → `toolkit.current_user` migration applied to keep authorisation checks consistent